### PR TITLE
Add default session manager for in memory session store

### DIFF
--- a/session.go
+++ b/session.go
@@ -1,0 +1,44 @@
+package buddy
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"sync"
+)
+
+// Potentially will need to be a sync Map
+type Context map[string]interface{}
+
+type SessionToken hash.Hash
+
+type SessionStore interface {
+	Get(SessionToken) (Context, error)
+	NewSession() SessionToken
+}
+
+type DefaultSessionStore struct {
+	sessionStore sync.Map
+}
+
+func (s *DefaultSessionStore) Get(token SessionToken) (Context, error) {
+	ctx, ok := s.sessionStore.Load(token)
+	if !ok {
+		return nil, fmt.Errorf("session does not exist")
+	}
+
+	return ctx.(Context), nil
+}
+
+func (s *DefaultSessionStore) NewSession() SessionToken {
+	// Initialize context fields
+	ctx := Context{}
+	token := sha256.New()
+	s.sessionStore.Store(token, ctx)
+
+	return token
+}
+
+func NewDefaultSessionManager() SessionStore {
+	return &DefaultSessionStore{}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,33 @@
+package buddy
+
+import (
+	"testing"
+)
+
+var (
+	store = NewDefaultSessionManager()
+)
+
+func TestDefaultSessionManagerNewSessionGet(t *testing.T) {
+	token := store.NewSession()
+
+	_, err := store.Get(token)
+	if err != nil {
+		t.Errorf("Failed to get session %v", err)
+	}
+}
+
+func TestContextPersistence(t *testing.T) {
+	token := store.NewSession()
+
+	ctx, _ := store.Get(token)
+
+	ctx["testVal"] = true
+
+	modifiedCtx, _ := store.Get(token)
+
+	if modifiedCtx["testVal"] != true {
+		t.Error("context did not save after setting value")
+	}
+
+}


### PR DESCRIPTION
Provides a basic in-memory session storage as well as a SessionStore interface that can be implemented for external session store servers such as redis, etc. 

The basics of this are the existence of a `DefaultSessionStore` which implements the 'SessionStore' as well as its methods and `Get(SessionToken)`, `NewSession()`. Sessions are identified by a SHA256 identifier, which should be included in each request so that session lookup works correctly.

The `Context` type implements a hashmap with string keys and interface values. By implementing with `interface{}` values we can assign any type to a key, allowing the addition of any data into a client's context. 

