### PR TITLE
Added middleware base as well as logger

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,53 @@
+package buddy
+
+import (
+	"log"
+	"os"
+)
+
+const (
+	InputChannelSize  = 256
+	OutputChannelSize = 256
+)
+
+var (
+	loggerMw = log.New(os.Stdout, "buddy: ", log.Lmicroseconds)
+)
+
+/*
+	Middlewares
+*/
+func logger(ctx *Context) {
+	loggerMw.Print("New Event: <event name> | Payload: <payload> | Other Data: <other_data>")
+}
+
+type MiddlewarePipeline struct {
+	In          chan Context
+	Out         chan Context
+	middlewares []func(*Context)
+}
+
+func (mw *MiddlewarePipeline) Run() {
+	func() {
+		for {
+			select {
+			case ctx := <-mw.In:
+				for _, f := range mw.middlewares {
+					f(&ctx)
+				}
+				mw.Out <- ctx
+			}
+		}
+	}()
+}
+
+func NewMiddlewarePipeline() *MiddlewarePipeline {
+	// List of middleware functions
+	mw := []func(*Context){logger}
+
+	return &MiddlewarePipeline{
+		In:          make(chan Context, InputChannelSize),
+		Out:         make(chan Context, OutputChannelSize),
+		middlewares: mw,
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,22 @@
+package buddy
+
+import (
+	"testing"
+)
+
+var (
+	Middleware = NewMiddlewarePipeline()
+)
+
+func TestMiddlewareRun(t *testing.T) {
+	go Middleware.Run()
+
+	ctx := make(Context)
+	ctx["hello"] = "world!"
+	Middleware.In <- ctx
+	out := <-Middleware.Out
+
+	if ctx["hello"] != out["hello"] {
+		t.Errorf("The input context was not equal to the output context: %v != %v", ctx, out)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -2,9 +2,9 @@ package buddy
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"sync"
-	"encoding/base64"
 )
 
 // Potentially will need to be a sync Map

--- a/session_test.go
+++ b/session_test.go
@@ -1,9 +1,9 @@
 package buddy
 
 import (
-	"testing"
 	"crypto/rand"
 	"encoding/base64"
+	"testing"
 )
 
 var (
@@ -66,7 +66,6 @@ func TestSessionExists(t *testing.T) {
 
 	stringToken := base64.URLEncoding.EncodeToString(b)
 	badToken := SessionToken(stringToken)
-
 
 	exists = store.Exists(badToken)
 


### PR DESCRIPTION
Adds a middleware module between the server and the dispatcher. Middlewares can be added by defining a function for them, then add the function into the middlewares slice on init. The middleware creation process is still a WiP. 