### PR TITLE
Fix bug where clients would hang if new connection rate was too high

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM partlab/ubuntu
+
+MAINTAINER Régis Gaidot <regis@partlab.co>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV INITRD No
+ENV LANG en_US.UTF-8
+ENV GOVERSION 1.9
+ENV GOROOT /opt/go
+ENV GOPATH /root/.go
+
+RUN cd /opt && wget https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz && \
+    tar zxf go${GOVERSION}.linux-amd64.tar.gz && rm go${GOVERSION}.linux-amd64.tar.gz && \
+    ln -s /opt/go/bin/go /usr/bin/ && \
+    mkdir $GOPATH
+
+RUN go get github.com/gorilla/websocket
+RUN cd /root/.go/src/github.com/ && mkdir senior-buddy
+RUN cd /root/.go/src/github.com/senior-buddy/ && git clone https://github.com/senior-buddy/buddy
+
+
+CMD ["/usr/bin/go"]
+

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 	"github.com/gorilla/websocket"
+	"fmt"
 )
 
 const (
@@ -195,6 +196,7 @@ func serveWs(server *Server, w http.ResponseWriter, r *http.Request) {
 	client.server.register <- client
 
 	func() {
+		fmt.Println("starting client!")
 		<-client.start
 		go client.writePump()
 		go client.readPump()

--- a/client.go
+++ b/client.go
@@ -194,12 +194,12 @@ func serveWs(server *Server, w http.ResponseWriter, r *http.Request) {
 		sendToken: make(chan SessionToken, sendTokenBufferSize),
 	}
 
-	fmt.Println(len(client.sendToken))
+	fmt.Println("Sent token!")
 	client.sendToken <- SessionToken(sessionToken)
-	fmt.Println(len(client.sendToken))
 
 	select {
 	case client.server.register <- client:
+		time.Sleep(time.Second)
 		fmt.Println("Registered!")
 		fmt.Println("Starting threads")
 		go client.writePump()

--- a/cmd/buddy.go
+++ b/cmd/buddy.go
@@ -13,6 +13,10 @@ func main() {
 	// start the session manager here
 
 	// start the server here
+
+	// do this to be able to handle large client counts
+	// ulimit -n SOME_REALLY_BIG_NUMBER
+	//
 	server := buddy.NewServer()
 	go server.Middleware.Run()
 	go server.Run()

--- a/middleware.go
+++ b/middleware.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	loggerMw = log.New(os.Stdout, "buddy: ", log.Lmicroseconds)
+	loggerMw = log.New(os.Stdout, "buddy: ", log.Ltime)
 )
 
 /*
@@ -24,7 +24,7 @@ var (
 
 func logger(req *Request) {
 	end := time.Now()
-	loggerMw.Printf("New Event: tbd | Elapsed Time: %v | Payload: %v",
+	loggerMw.Printf("middleware: new event: tbd | elapsed time: %v | payload: %v",
 		end.Sub(req.startTime), string(req.message[:]))
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -37,7 +37,7 @@ func (mw *MiddlewarePipeline) Run() {
 				for _, f := range mw.middlewares {
 					f(req)
 				}
-				mw.Out <- req
+				//mw.Out <- req
 			}
 		}
 	}()

--- a/middleware.go
+++ b/middleware.go
@@ -2,17 +2,12 @@ package buddy
 
 import (
 	"log"
-	"os"
 	"time"
 )
 
 const (
 	InputChannelSize  = 256
 	OutputChannelSize = 256
-)
-
-var (
-	loggerMw = log.New(os.Stdout, "buddy: ", log.Ltime)
 )
 
 /*
@@ -24,7 +19,7 @@ var (
 
 func logger(req *Request) {
 	end := time.Now()
-	loggerMw.Printf("middleware: new event: tbd | elapsed time: %v | payload: %v",
+	log.Printf("middleware: new event: tbd | elapsed time: %v | payload: %v\n",
 		end.Sub(req.startTime), string(req.message[:]))
 }
 

--- a/request.go
+++ b/request.go
@@ -1,21 +1,21 @@
 package buddy
 
 import (
-//"fmt"
-//"log"
+	//"fmt"
+	//"log"
 	"time"
 )
 
 type Request struct {
-	session *Session
-	message []byte
+	session   *Session
+	message   []byte
 	startTime time.Time
 }
 
 func NewRequest(session *Session, message []byte) *Request {
 	return &Request{
-		session: session,
-		message: message,
+		session:   session,
+		message:   message,
 		startTime: time.Now(),
 	}
 }

--- a/server.go
+++ b/server.go
@@ -47,13 +47,14 @@ func (svr *Server) Run() {
 		select {
 		case client := <-svr.register:
 			client.open = true
-			fmt.Println(len(client.sendToken))
+			fmt.Printf("Len before grab from buffer: %v\n", len(client.sendToken))
 			token := <-client.sendToken
-			fmt.Println(len(client.sendToken))
+			fmt.Printf("Len after grab from buffer: %v\n", len(client.sendToken))
 			fmt.Println("BEGIN REGISTER")
 			//create persistent token for new or invalid sessions
 			exists := svr.sessions.Exists(token)
-			if (token == "nil") || !exists {
+			fmt.Println(exists)
+			if (token == "") || !exists {
 				var err error
 				token, err = svr.sessions.NewSession()
 				if err != nil {

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	serverSecret         = "37FUqWlvJhRgwPMM1mlHOGyPNwkVna3b"
-	broadcastChannelSize = 512
+	broadcastChannelSize = 4096
 	port                 = 8080
 )
 

--- a/server.go
+++ b/server.go
@@ -47,13 +47,9 @@ func (svr *Server) Run() {
 		select {
 		case client := <-svr.register:
 			client.open = true
-			fmt.Printf("Len before grab from buffer: %v\n", len(client.sendToken))
 			token := <-client.sendToken
-			fmt.Printf("Len after grab from buffer: %v\n", len(client.sendToken))
-			fmt.Println("BEGIN REGISTER")
 			//create persistent token for new or invalid sessions
 			exists := svr.sessions.Exists(token)
-			fmt.Println(exists)
 			if (token == "") || !exists {
 				var err error
 				token, err = svr.sessions.NewSession()
@@ -66,6 +62,7 @@ func (svr *Server) Run() {
 			}
 
 			svr.sessions.SetClient(token, client)
+			close(client.start)
 		case client := <-svr.unregister:
 			if client.open {
 				client.open = false

--- a/session.go
+++ b/session.go
@@ -4,9 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"sync"
 	"time"
-	"log"
 )
 
 const (
@@ -89,7 +89,7 @@ func (s *DefaultSessionStore) NewSession() (SessionToken, error) {
 	s.length += 1
 	s.mutex.Unlock()
 
-	log.Printf("session: new session created %v, total: %v\n", token,s.length)
+	log.Printf("session: new session created %v, total: %v\n", token, s.length)
 
 	return token, nil
 }


### PR DESCRIPTION
Prior to this, if the connection rate was more than one connection per 0.01 seconds, the server would get into a race condition, then deadlock since client registration could not take place before the read and write pumps started. This fix makes the read and write pumps wait for a start channel to close, thus unblocking and acting as a starting gate, before starting the read and write pumps. 